### PR TITLE
Allow for customization of starting point of animation within an individual progress bar

### DIFF
--- a/library/src/main/java/jp/shts/android/storiesprogressview/PausableProgressBar.java
+++ b/library/src/main/java/jp/shts/android/storiesprogressview/PausableProgressBar.java
@@ -5,6 +5,7 @@ import androidx.annotation.AttrRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.animation.Animation;
@@ -95,11 +96,18 @@ final class PausableProgressBar extends FrameLayout {
         }
     }
 
-    public void startProgress() {
+    public void startProgress(long startTime) {
         maxProgressView.setVisibility(GONE);
 
-        animation = new PausableScaleAnimation(0, 1, 1, 1, Animation.ABSOLUTE, 0, Animation.RELATIVE_TO_SELF, 0);
-        animation.setDuration(duration);
+        long remainingTime = duration - startTime;
+        if(remainingTime < 0) {
+            throw new IllegalArgumentException("Start time is greater than story duration");
+        }
+        float fromX = 1.0f - ((float)remainingTime/(float)duration);
+        Log.d("PausableProgressBar", "fromX = " + fromX);
+        animation = new PausableScaleAnimation(fromX, 1, 1, 1, Animation.ABSOLUTE, 0, Animation.RELATIVE_TO_SELF, 0);
+        animation.setDuration(remainingTime);
+
         animation.setInterpolator(new LinearInterpolator());
         animation.setAnimationListener(new Animation.AnimationListener() {
             @Override

--- a/library/src/main/java/jp/shts/android/storiesprogressview/PausableProgressBar.java
+++ b/library/src/main/java/jp/shts/android/storiesprogressview/PausableProgressBar.java
@@ -104,7 +104,7 @@ final class PausableProgressBar extends FrameLayout {
             throw new IllegalArgumentException("Start time is greater than story duration");
         }
         float fromX = 1.0f - ((float)remainingTime/(float)duration);
-        Log.d("PausableProgressBar", "fromX = " + fromX);
+
         animation = new PausableScaleAnimation(fromX, 1, 1, 1, Animation.ABSOLUTE, 0, Animation.RELATIVE_TO_SELF, 0);
         animation.setDuration(remainingTime);
 

--- a/library/src/main/java/jp/shts/android/storiesprogressview/StoriesProgressView.java
+++ b/library/src/main/java/jp/shts/android/storiesprogressview/StoriesProgressView.java
@@ -178,9 +178,9 @@ public class StoriesProgressView extends LinearLayout {
                     if (0 <= (current - 1)) {
                         PausableProgressBar p = progressBars.get(current - 1);
                         p.setMinWithoutCallback();
-                        progressBars.get(--current).startProgress();
+                        progressBars.get(--current).startProgress(0);
                     } else {
-                        progressBars.get(current).startProgress();
+                        progressBars.get(current).startProgress(0);
                     }
                     isReverseStart = false;
                     return;
@@ -188,7 +188,7 @@ public class StoriesProgressView extends LinearLayout {
                 int next = current + 1;
                 if (next <= (progressBars.size() - 1)) {
                     if (storiesListener != null) storiesListener.onNext();
-                    progressBars.get(next).startProgress();
+                    progressBars.get(next).startProgress(0);
                 } else {
                     isComplete = true;
                     if (storiesListener != null) storiesListener.onComplete();
@@ -202,17 +202,21 @@ public class StoriesProgressView extends LinearLayout {
      * Start progress animation
      */
     public void startStories() {
-        progressBars.get(0).startProgress();
+        progressBars.get(0).startProgress(0);
     }
 
     /**
      * Start progress animation from specific progress
      */
     public void startStories(int from) {
+        startStories(from, 0);
+    }
+
+    public void startStories(int from, long startTime) {
         for (int i = 0; i < from; i++) {
             progressBars.get(i).setMaxWithoutCallback();
         }
-        progressBars.get(from).startProgress();
+        progressBars.get(from).startProgress(startTime);
     }
 
     /**


### PR DESCRIPTION
Allows for passing a second argument to `StoriesProgressView.startStories(...)` which will allow the caller to specify at which duration to start the animation within the current progress bar from.

Example: 
```
storiesProgressView = (StoriesProgressView) findViewById(R.id.stories);
storiesProgressView.setStoriesCount(6);
storiesProgressView.setStoryDuration(3000L);
// ...
// This will start the animation on half of the third progress bar
storiesProgressView.startStories(2, 1500L);```
