### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+                   android:exported="true"
+                  >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
 android:exported="" is now required for every activity that contains inter-filter.